### PR TITLE
移动端会话列表：切换tab的时候有时会出现列表一直在加载中

### DIFF
--- a/web/src/views/mobile/ChatList.vue
+++ b/web/src/views/mobile/ChatList.vue
@@ -170,8 +170,8 @@ checkSession().then((user) => {
 })
 
 const onLoad = () => {
-  checkSession().then(() => {
-    httpGet("/api/chat/list?user_id=" + loginUser.value.id).then((res) => {
+  checkSession().then((user) => {
+    httpGet("/api/chat/list?user_id=" + user.id).then((res) => {
       if (res.data) {
         chats.value = res.data;
         allChats.value = res.data;

--- a/web/src/views/mobile/ChatList.vue
+++ b/web/src/views/mobile/ChatList.vue
@@ -182,7 +182,9 @@ const onLoad = () => {
       error.value = true
       showFailToast("加载会话列表失败")
     })
-  }).catch(() => {})
+  }).catch(() => {
+    finished.value = true
+  })
 };
 
 const search = () => {


### PR DESCRIPTION
<!-- 📢 注意：

在提交的 PR 的时候请确保每个 PR 只包含一个功能修改或者优化，请不要把多个更改组合到一个 PR 提交。保持干净可管理的 git 历史记录至关重要。 为确保我们存储库的质量，我们恳请您在提交 PR 时遵守以下准则：

1. 每个 PR 专注于一个单一的、具体的改进。
2. 不要包括任何不相关或[额外]的修改。
3. 为所做的更改提供清晰的文档和解释。
-->

### Background
在请求会话列表的接口时  有可能 loginUser的值还没有赋值 导致异常进入catch中，catch未做任何处理，所以列表状态在一直加载中

### Changes
把checkSession的结果user中的id的值 赋给参数user_id,并在catch中修改加载中的状态

### Test Plan
来回切换tab：首页->对话<-绘图 就可以复现

### PR 规则验证列表
- [x] 确保本次 PR 只包含单一的功能修改。
- [x] 我已经对我的代码更改进行了充分的测试。
- [x] 我已经考虑了我的更改的潜在风险和缓解措施。
- [x] 我已经修正了相关文档 

